### PR TITLE
Python 3 compatibility and consistent UI

### DIFF
--- a/octoprint_sidebarorder/__init__.py
+++ b/octoprint_sidebarorder/__init__.py
@@ -9,8 +9,7 @@ class sidebarorder(octoprint.plugin.AssetPlugin,
 	
 	##-- AssetPlugin mixin
 	def get_assets(self):
-		return dict(js=["js/sidebarorder.js"],
-					css=["css/sidebarorder.css"])
+		return dict(js=["js/sidebarorder.js"])
 		
 	##-- Settings mixin
 	def get_settings_defaults(self):

--- a/octoprint_sidebarorder/__init__.py
+++ b/octoprint_sidebarorder/__init__.py
@@ -56,6 +56,8 @@ class sidebarorder(octoprint.plugin.AssetPlugin,
 		)
 
 __plugin_name__ = "Sidebar Order"
+__plugin_version__ = "0.3.1"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-SidebarOrder"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.3.0"
+plugin_version = "0.3.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- Added pythoncompat flag so that the plugin also supports OctoPrint running with Python3
- Removed CSS from assets to create a consistent UI if the notification pops up
- Increased the version